### PR TITLE
Fixed KeyError on get_jenkins_queue_metrics

### DIFF
--- a/prometheus_jenkins_exporter/exporter.py
+++ b/prometheus_jenkins_exporter/exporter.py
@@ -139,7 +139,7 @@ class JenkinsMetricsCollector():
             status = 1
 
         metrics = [
-                {
+            {
                 "name": "slave_up",
                 "value": status,
                 "labels": {"display_name": slave['displayName']}
@@ -162,7 +162,7 @@ class JenkinsMetricsCollector():
         if len(response["data"]["items"]) > 0:
             oldest = min([item["inQueueSince"] for item in response["data"]["items"]], default=0)
             if oldest > 0:
-                metrics[0]["queue_oldest_job_since_seconds"]["value"] = time.time() - (oldest / 1000)
+                metrics[0]["value"] = time.time() - (oldest / 1000)
 
         return metrics
 


### PR DESCRIPTION
I realized it was throwing an exception: 

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/socketserver.py", line 654, in process_request_thread
    self.finish_request^C(request, client_address)
  File "/usr/lib/python3.6/socketserver.py", line 364, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.6/socketserver.py", line 724, in __init__
    self.handle()
  File "/usr/lib/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/usr/lib/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "/usr/lib/python3.6/site-packages/prometheus_client/exposition.py", line 86, in do_GET
    output = generate_latest(registry)
  File "/usr/lib/python3.6/site-packages/prometheus_client/exposition.py", line 63, in generate_latest
    for metric in registry.collect():
  File "/usr/lib/python3.6/site-packages/prometheus_client/core.py", line 97, in collect
    for metric in collector.collect():
  File "/usr/lib/python3.6/site-packages/prometheus_jenkins_exporter/exporter.py", line 80, in collect
    metrics = self.get_jenkins_metrics()
  File "/usr/lib/python3.6/site-packages/prometheus_jenkins_exporter/exporter.py", line 94, in get_jenkins_metrics
    metrics.extend(self.get_jenkins_queue_metrics())
  File "/usr/lib/python3.6/site-packages/prometheus_jenkins_exporter/exporter.py", line 165, in get_jenkins_queue_metrics
    metrics[0]["queue_oldest_job_since_seconds"]["value"] = time.time() - (oldest / 1000)
KeyError: 'queue_oldest_job_since_seconds'
```